### PR TITLE
Updates for DSpace 5 Deployment

### DIFF
--- a/roles/dspace/tasks/main.yml
+++ b/roles/dspace/tasks/main.yml
@@ -7,7 +7,6 @@
     - ant
     - maven
     - libtcnative-1
-    - lrzip
     - poppler-utils # for media filter
     - python-psycopg2 # for ansible postgres modules
     - postgresql-contrib # for DSpace functions

--- a/roles/dspace/tasks/main.yml
+++ b/roles/dspace/tasks/main.yml
@@ -6,7 +6,6 @@
     - tomcat7-admin
     - ant
     - maven
-    - xpdf
     - libtcnative-1
     - lrzip
     - poppler-utils # for media filter


### PR DESCRIPTION
I missed these before when I was preparing the DSpace role for DSpace 5 in mid 2015. These are just some packages we're not using anymore.
