### PR TITLE
roles/dspace: Specify that nginx keepalive_timeout is in seconds

### DIFF
--- a/roles/dspace/files/nginx/nginx.conf
+++ b/roles/dspace/files/nginx/nginx.conf
@@ -26,7 +26,7 @@ http {
     sendfile        on;
     #tcp_nopush     on;
 
-    keepalive_timeout  65;
+    keepalive_timeout  65s;
 
     gzip on;
     gzip_vary on;


### PR DESCRIPTION
Apparently not a fatal syntax error, but nevertheless incorrect.

See: http://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_timeout
