### PR TITLE
roles/dspace: Add task to set the tomcat7 user's open file limits

### DIFF
--- a/roles/dspace/files/etc/security/limits.d/90-tomcat7.conf
+++ b/roles/dspace/files/etc/security/limits.d/90-tomcat7.conf
@@ -1,0 +1,5 @@
+# Allow tomcat7 user to open more files (ie, in cron jobs). We have also set
+# this limit in /etc/default/tomcat7 for the Tomcat application itself. I'm
+# not sure if pam_limits applies there (it doesn't apply for su shells,
+# for example), so we should leave them both.
+tomcat7          -       nofile          16384

--- a/roles/dspace/tasks/main.yml
+++ b/roles/dspace/tasks/main.yml
@@ -101,6 +101,10 @@
   copy: src=etc/logrotate.d/tomcat7-access_logs dest=/etc/logrotate.d/tomcat7-access_logs owner=root group=root mode=0644
   tags: tomcat
 
+- name: Set open file limits for tomcat7 user
+  copy: src=etc/security/limits.d/90-tomcat7.conf dest=/etc/security/limits.d/90-tomcat7.conf owner=root group=root mode=0644
+  tags: tomcat
+
 - name: Copy maven settings
   template: src=m2/settings.xml.j2 dest=/usr/share/tomcat7/.m2/settings.xml owner=tomcat7 group=tomcat7 mode=640
   when: maven_username is defined and maven_password is defined


### PR DESCRIPTION
We set the Tomcat application's open file limits in `/etc/default/tomcat7` but that is only for the servlet container. The tomcat7 user also runs some batch jobs from cron and I've noticed that the log files have errors about "too many open files" for those jobs.

Note: this limits file will take effect for cron jobs, but not for interactive sessions like when we `su - tomcat7` for building and deploying. See "pam_limits" in `/etc/pam.d/*`.

Tested on DSpace Test.
