### PR TITLE
roles/dspace: Block robots from accessing dynamic pages in nginx vhost

### DIFF
--- a/roles/dspace/templates/nginx/default.conf.j2
+++ b/roles/dspace/templates/nginx/default.conf.j2
@@ -215,6 +215,18 @@ server {
         }
     }
 
+    # block robots from crawling dynamic URLs (because we can't use * in robots.txt!)
+    # see: https://jira.duraspace.org/browse/DS-2962
+    location ~ /handle/10568/[0-9]+/(browse|discover|search-filter) {
+        add_header X-Robots-Tag "none";
+
+        {% if nginx_tls_cert is defined %}
+        proxy_pass http://127.0.0.1:8443;
+        {% else %}
+        proxy_pass http://127.0.0.1:8081;
+        {% endif %}
+    }
+
     location / {
         # Send requests to Tomcat
         {% if nginx_tls_cert is defined %}


### PR DESCRIPTION
We had been doing it in robots.txt, but it turns out that you can't use "*" for URL patterns in robots.txt. The only option is to block these URLs in the webserver via X-Robots-Tag.

A few URLs to test with:
- https://cgspace.cgiar.org/handle/10568/440/browse?type=bioversity
- https://cgspace.cgiar.org/handle/10568/913/discover
- https://cgspace.cgiar.org/handle/10568/1/search-filter?filtertype_0=country&filter_0=VIETNAM&filter_relational_operator_0=equals&field=country

Test with `httpie --print Hh` to see the header.
