### PR TITLE
Update DSpace role to nginx  1.10.0

### DIFF
--- a/group_vars/dspace
+++ b/group_vars/dspace
@@ -25,7 +25,7 @@ dspace_git_repo: https://github.com/ilri/DSpace.git
 dspace_git_branch: 5_x-prod
 
 # stable is 1.10.x
-# mainline is 1.9.x
+# mainline is 1.11.x
 nginx_branch: stable
 
 munin_tomcat_user: ilri-munin

--- a/group_vars/dspace
+++ b/group_vars/dspace
@@ -24,7 +24,7 @@ tls_cipher_suite: "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECD
 dspace_git_repo: https://github.com/ilri/DSpace.git
 dspace_git_branch: 5_x-prod
 
-# stable is 1.8.x
+# stable is 1.10.x
 # mainline is 1.9.x
 nginx_branch: stable
 

--- a/roles/dspace/templates/nginx/blank-vhost.conf.j2
+++ b/roles/dspace/templates/nginx/blank-vhost.conf.j2
@@ -4,11 +4,7 @@
 # a vhost serving that domain.
 server {
     listen 80 default;
-    {% if nginx_branch == "stable" %}
-    listen 443 ssl spdy default;
-    {% elif nginx_branch == "mainline" %}
     listen 443 ssl http2 default;
-    {% endif %}
     server_name _;
 
     # "snakeoil" certificate (self signed!)

--- a/roles/dspace/templates/nginx/default.conf.j2
+++ b/roles/dspace/templates/nginx/default.conf.j2
@@ -100,11 +100,7 @@ server {
 # ... check Google for "inurl:mahider.ilri.org inurl:https"
 # ... check Google for "inurl:dspace.ilri.org inurl:https"
 server {
-    {% if nginx_branch == "stable" %}
-    listen 443 ssl spdy;
-    {% elif nginx_branch == "mainline" %}
     listen 443 ssl http2;
-    {% endif %}
     server_name dspace.ilri.org mahider.ilri.org;
 
     ssl_certificate {{ nginx_ilri_tls_cert }};
@@ -127,11 +123,6 @@ server {
     # of such infrastructure, consider turning off session tickets:
     ssl_session_tickets off;
 
-    {% if nginx_branch == "stable" %}
-    # enable SPDY header compression
-    spdy_headers_comp {{ nginx_spdy_headers_comp }};
-    {% endif %}
-
     # Add header to forbid robots to index
     # See: https://developers.google.com/webmasters/control-crawl-index/docs/robots_meta_tag
     # May, 2015 we submitted a "Change of Address" -> cgspace.cgiar.org in Google Webmaster tools
@@ -152,13 +143,8 @@ server {
 #
 server {
     {% if nginx_tls_cert is defined %}
-    {% if nginx_branch == "stable" %}
-    listen 443 ssl spdy;
-    listen [::]:443 ssl spdy;
-    {% elif nginx_branch == "mainline" %}
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
-    {% endif %} {# end: nginx_branch #}
     {% else %}
     listen 80;
     listen [::]:80;
@@ -194,11 +180,6 @@ server {
     # Note that you'll have to define and rotate the keys securely by yourself. In absence
     # of such infrastructure, consider turning off session tickets:
     ssl_session_tickets off;
-
-    {% if nginx_branch == "stable" %}
-    # enable SPDY header compression
-    spdy_headers_comp 6;
-    {% endif %}
 
     {% if nginx_enable_hsts == True %}
     # Enable this if you want HSTS (recommended, but be careful)

--- a/roles/dspace/templates/nginx_org_packages_ubuntu.list.j2
+++ b/roles/dspace/templates/nginx_org_packages_ubuntu.list.j2
@@ -1,16 +1,7 @@
-{% if ansible_distribution_version == '14.04' %}
+{% if ansible_distribution == 'Ubuntu' %}
 {% if nginx_branch == "stable" %}
 deb http://nginx.org/packages/ubuntu/ {{ ansible_distribution_release }} nginx
 {% elif nginx_branch == "mainline" %}
 deb http://nginx.org/packages/mainline/ubuntu/ {{ ansible_distribution_release }} nginx
-{% endif %}
-{% endif %}
-
-{% if ansible_distribution_version == '15.04' %}
-# There are no "stable" nginx.org builds for Ubuntu 15.04 (vivid) yet, so use 14.10 (utopic)
-{% if nginx_branch == "stable" %}
-deb http://nginx.org/packages/ubuntu/ utopic nginx
-{% elif nginx_branch == "mainline" %}
-deb http://nginx.org/packages/mainline/ubuntu/ vivid nginx
 {% endif %}
 {% endif %}


### PR DESCRIPTION
Nginx 1.10.x was released last week. Config updates were proposed in #32 and have been running on the development server for the past week without any issues. Furthermore, nginx 1.10.0 is based on 1.9.x which has been running for over six months on our development server.

Ready to merge (and has already been deployed on production). Closes #32.
