### PR TITLE
Update nginx configs

### DIFF
--- a/group_vars/dspace
+++ b/group_vars/dspace
@@ -25,7 +25,7 @@ dspace_git_repo: https://github.com/ilri/DSpace.git
 dspace_git_branch: 5_x-prod
 
 # stable is 1.10.x
-# mainline is 1.9.x
+# mainline is 1.11.x
 nginx_branch: stable
 
 munin_tomcat_user: ilri-munin

--- a/group_vars/dspace
+++ b/group_vars/dspace
@@ -24,7 +24,7 @@ tls_cipher_suite: "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECD
 dspace_git_repo: https://github.com/ilri/DSpace.git
 dspace_git_branch: 5_x-prod
 
-# stable is 1.8.x
+# stable is 1.10.x
 # mainline is 1.9.x
 nginx_branch: stable
 

--- a/roles/dspace/templates/nginx/blank-vhost.conf.j2
+++ b/roles/dspace/templates/nginx/blank-vhost.conf.j2
@@ -4,11 +4,7 @@
 # a vhost serving that domain.
 server {
     listen 80 default;
-    {% if nginx_branch == "stable" %}
-    listen 443 ssl spdy default;
-    {% elif nginx_branch == "mainline" %}
     listen 443 ssl http2 default;
-    {% endif %}
     server_name _;
 
     # "snakeoil" certificate (self signed!)

--- a/roles/dspace/templates/nginx/blank-vhost.conf.j2
+++ b/roles/dspace/templates/nginx/blank-vhost.conf.j2
@@ -4,6 +4,13 @@
 # a vhost serving that domain.
 server {
     listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name _;
+
+    return 444;
+}
+
+server {
     listen 443 ssl http2 default_server;
     # specify an invalid hostname that will never match
     # see: http://nginx.org/en/docs/http/server_names.html

--- a/roles/dspace/templates/nginx/blank-vhost.conf.j2
+++ b/roles/dspace/templates/nginx/blank-vhost.conf.j2
@@ -3,8 +3,8 @@
 # clients asking for "example.com" should only get a response if we have
 # a vhost serving that domain.
 server {
-    listen 80 default;
-    listen 443 ssl http2 default;
+    listen 80 default_server;
+    listen 443 ssl http2 default_server;
     server_name _;
 
     # "snakeoil" certificate (self signed!)

--- a/roles/dspace/templates/nginx/blank-vhost.conf.j2
+++ b/roles/dspace/templates/nginx/blank-vhost.conf.j2
@@ -30,5 +30,5 @@ server {
     # of such infrastructure, consider turning off session tickets:
     ssl_session_tickets off;
 
-    return 403;
+    return 444;
 }

--- a/roles/dspace/templates/nginx/blank-vhost.conf.j2
+++ b/roles/dspace/templates/nginx/blank-vhost.conf.j2
@@ -12,6 +12,7 @@ server {
 
 server {
     listen 443 ssl http2 default_server;
+    listen [::]:443 ssl http2 default_server;
     # specify an invalid hostname that will never match
     # see: http://nginx.org/en/docs/http/server_names.html
     server_name _;

--- a/roles/dspace/templates/nginx/blank-vhost.conf.j2
+++ b/roles/dspace/templates/nginx/blank-vhost.conf.j2
@@ -5,6 +5,8 @@
 server {
     listen 80 default_server;
     listen 443 ssl http2 default_server;
+    # specify an invalid hostname that will never match
+    # see: http://nginx.org/en/docs/http/server_names.html
     server_name _;
 
     # "snakeoil" certificate (self signed!)

--- a/roles/dspace/templates/nginx/default.conf.j2
+++ b/roles/dspace/templates/nginx/default.conf.j2
@@ -100,11 +100,7 @@ server {
 # ... check Google for "inurl:mahider.ilri.org inurl:https"
 # ... check Google for "inurl:dspace.ilri.org inurl:https"
 server {
-    {% if nginx_branch == "stable" %}
-    listen 443 ssl spdy;
-    {% elif nginx_branch == "mainline" %}
     listen 443 ssl http2;
-    {% endif %}
     server_name dspace.ilri.org mahider.ilri.org;
 
     ssl_certificate {{ nginx_ilri_tls_cert }};
@@ -127,11 +123,6 @@ server {
     # of such infrastructure, consider turning off session tickets:
     ssl_session_tickets off;
 
-    {% if nginx_branch == "stable" %}
-    # enable SPDY header compression
-    spdy_headers_comp {{ nginx_spdy_headers_comp }};
-    {% endif %}
-
     # Add header to forbid robots to index
     # See: https://developers.google.com/webmasters/control-crawl-index/docs/robots_meta_tag
     # May, 2015 we submitted a "Change of Address" -> cgspace.cgiar.org in Google Webmaster tools
@@ -152,13 +143,8 @@ server {
 #
 server {
     {% if nginx_tls_cert is defined %}
-    {% if nginx_branch == "stable" %}
-    listen 443 ssl spdy;
-    listen [::]:443 ssl spdy;
-    {% elif nginx_branch == "mainline" %}
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
-    {% endif %} {# end: nginx_branch #}
     {% else %}
     listen 80;
     listen [::]:80;
@@ -194,11 +180,6 @@ server {
     # Note that you'll have to define and rotate the keys securely by yourself. In absence
     # of such infrastructure, consider turning off session tickets:
     ssl_session_tickets off;
-
-    {% if nginx_branch == "stable" %}
-    # enable SPDY header compression
-    spdy_headers_comp 6;
-    {% endif %}
 
     {% if nginx_enable_hsts == True %}
     # Enable this if you want HSTS (recommended, but be careful)

--- a/roles/dspace/templates/nginx_org_packages_ubuntu.list.j2
+++ b/roles/dspace/templates/nginx_org_packages_ubuntu.list.j2
@@ -1,16 +1,7 @@
-{% if ansible_distribution_version == '14.04' %}
+{% if ansible_distribution == 'Ubuntu' %}
 {% if nginx_branch == "stable" %}
 deb http://nginx.org/packages/ubuntu/ {{ ansible_distribution_release }} nginx
 {% elif nginx_branch == "mainline" %}
 deb http://nginx.org/packages/mainline/ubuntu/ {{ ansible_distribution_release }} nginx
-{% endif %}
-{% endif %}
-
-{% if ansible_distribution_version == '15.04' %}
-# There are no "stable" nginx.org builds for Ubuntu 15.04 (vivid) yet, so use 14.10 (utopic)
-{% if nginx_branch == "stable" %}
-deb http://nginx.org/packages/ubuntu/ utopic nginx
-{% elif nginx_branch == "mainline" %}
-deb http://nginx.org/packages/mainline/ubuntu/ vivid nginx
 {% endif %}
 {% endif %}


### PR DESCRIPTION
A bit of spring cleaning and updates to convention:
- Add IPv6 listeners for all vhosts
- Use `default_server` instead of `default` in configs (this is actually the correct [keyword since nginx 0.8.21](http://nginx.org/en/docs/http/request_processing.html))
- Update comment for `server_name` config so that it's clear that this is not a "magical" reserved keyword or something
- Return [nginx-specific HTTP 444 for requests to non-existent vhosts](http://nginx.org/en/docs/http/request_processing.html#how_to_prevent_undefined_server_names) instead of HTTP 403, see respective examples for CGSpace and DSpace Test here:

```
$ http --print Hh 178.79.187.182
GET / HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate
Connection: keep-alive
Host: 178.79.187.182
User-Agent: HTTPie/0.9.3

HTTP/1.1 403 Forbidden
Connection: keep-alive
Content-Length: 162
Content-Type: text/html
Date: Tue, 03 May 2016 09:19:32 GMT
Server: nginx

$ http --print Hh 178.79.166.38

http: error: ConnectionError: ('Connection aborted.', BadStatusLine("''",)) while doing GET request to URL: http://178.79.166.38/
```

Depends on pull request #33. Closes #28.
