### PR TITLE
roles/common: Update sources for cron-apt

### DIFF
--- a/roles/common/templates/security.sources.list.j2
+++ b/roles/common/templates/security.sources.list.j2
@@ -1,5 +1,5 @@
 {% if ansible_distribution == 'Ubuntu' %}
-deb http://security.ubuntu.com/ubuntu {{ ansible_distribution_release }}-security main universe
+deb http://security.ubuntu.com/ubuntu {{ ansible_distribution_release }}-security main restricted universe multiverse
 {% elif ansible_distribution == 'Debian' %}
 deb http://security.debian.org/ {{ ansible_distribution_release }}/updates main
 {% endif %}


### PR DESCRIPTION
The system's apt configuration is using restricted and multiverse so the security sources list should as well. Tested by running:

```
$ sudo cron-apt /etc/cron-apt/config
```

`/var/log/cron-apt/log` shows the run was successful.
