### PR TITLE
roles/dspace: Add nginx mitigation for HTTPoxy vulnerability

### DIFF
--- a/roles/dspace/files/nginx/proxy_params
+++ b/roles/dspace/files/nginx/proxy_params
@@ -2,6 +2,10 @@ proxy_set_header Host $http_host;
 proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Forwarded-Proto $scheme;
+# Protect against "HTTPoxy" vulnerability in server-side libraries
+# See: https://www.nginx.com/blog/mitigating-the-httpoxy-vulnerability-with-nginx/
+# See: https://httpoxy.org/
+proxy_set_header Proxy "";
 proxy_connect_timeout 3600;
 proxy_send_timeout 3600;
 proxy_read_timeout 3600;


### PR DESCRIPTION
Already running on linode01 and linode02. HTTP_PROXY is non standard anyways, so this is safe to just flat out block.

See: https://httpoxy.org
See: https://www.nginx.com/blog/mitigating-the-httpoxy-vulnerability-with-nginx/
