### PR TITLE
Add 'packages' tag to relevant tasks

### DIFF
--- a/roles/postgres/tasks/ubuntu.yml
+++ b/roles/postgres/tasks/ubuntu.yml
@@ -3,9 +3,11 @@
 
 - name: Add PGDG apt list file
   template: src=pgdg.list.j2 dest=/etc/apt/sources.list.d/pgdg.list owner=root group=root mode=0644
+  tags: packages
 
 - name: Import PGDG repo keys
   apt_key: url="https://www.postgresql.org/media/keys/ACCC4CF8.asc" state=present
+  tags: packages
 
 - name: Install postgresql
   apt: name={{ item }} update_cache=yes state=present
@@ -15,6 +17,7 @@
     - postgresql-contrib-{{ pg_version }}
   notify:
     - restart postgres
+  tags: packages
 
 - name: Create additional postgresql configs. directory
   file: path={{ pg_conf_dir }}/conf.d mode=0755 owner=postgres group=postgres state=directory


### PR DESCRIPTION
I was running the 'packages' tag on a new host and noticed that the postgres package tasks weren't tagged properly and this causes problems with missing packages (namely the dspace role tries to install the appropriate contrib package, which isn't in the index yet).

After all, these tasks are related to the system's package manager and should be tagged appropriately!
