### PR TITLE
roles/common: Add a few SHA-2 MACs to Ubuntu 16.04's sshd_config

### DIFF
--- a/roles/common/templates/sshd_config_Ubuntu-16.04.j2
+++ b/roles/common/templates/sshd_config_Ubuntu-16.04.j2
@@ -87,7 +87,7 @@ UsePAM yes
 
 # https://stribika.github.io/2015/01/04/secure-secure-shell.html
 Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes128-ctr
-MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-ripemd160-etm@openssh.com,umac-128-etm@openssh.com
+MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-ripemd160-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256
 KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
 
 {% if ssh_allowed_users is defined and ssh_allowed_users %}


### PR DESCRIPTION
Fixes a problem with Paramiko, which Ansible uses for transport.

See: http://www.paramiko.org/changelog.html#1.16.0
See: https://github.com/ilri/rmg-ansible-public/issues/37
