### PR TITLE
roles/common: Use timedatectl for NTP on hosts with systemd

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -14,4 +14,7 @@ mailrc_from_email: mwangi@example.co.ke
 mailrc_auth_user: mwangi@example.co.ke
 mailrc_auth_pass: A2YtYma2i1D1
 
+## use UTC as the default timezone
+timezone: Etc/UTC
+
 # vim: set ts=2 sw=2:

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -18,6 +18,9 @@
 - include: sshd.yml
   tags: sshd
 
+- include: ntp.yml
+  tags: ntp
+
 - name: Reconfigure /etc/sysctl.conf
   template: src=sysctl_{{ ansible_distribution }}.j2 dest=/etc/sysctl.conf owner=root group=root mode=0644
   notify:

--- a/roles/common/tasks/ntp.yml
+++ b/roles/common/tasks/ntp.yml
@@ -1,0 +1,35 @@
+---
+# Hosts running Ubuntu 16.04 or CentOS 7 use the systemd init system and should
+# use timedatectl as a network time client instead of the standalone ntp client.
+# Earlier versions of those distros should use the ntp/ntpd package.
+
+- name: Set timezone
+  when: timezone is defined and ansible_service_mgr == 'systemd'
+  command: /usr/bin/timedatectl set-timezone {{ timezone }}
+  tags: timezone
+
+- name: Enable systemd's NTP client
+  when: ansible_service_mgr == 'systemd'
+  service: name=systemd-timesyncd enabled=yes
+
+- name: Uninstall ntp on modern Ubuntu/Debian
+  apt: name=ntp state=absent update_cache=yes
+  when: ansible_os_family == 'Debian' and ansible_service_mgr == 'systemd'
+  tags: packages
+
+- name: Uninstall ntp on modern CentOS
+  yum: name=ntp state=absent update_cache=yes
+  when: ansible_distribution == 'CentOS' and ansible_service_mgr == 'systemd'
+  tags: packages
+
+- name: Install ntp on old Ubuntu/Debian
+  apt: name=ntp state=present update_cache=yes
+  when: ansible_os_family == 'Debian' and ansible_service_mgr != 'systemd'
+  tags: packages
+
+- name: Install ntp on old CentOS
+  yum: name=ntp state=present update_cache=yes
+  when: ansible_distribution == 'CentOS' and ansible_service_mgr != 'systemd'
+  tags: packages
+
+# vim: set ts=2 sw=2:

--- a/roles/common/tasks/packages_Debian.yml
+++ b/roles/common/tasks/packages_Debian.yml
@@ -5,7 +5,6 @@
 - name: Install base packages
   apt: name={{ item }} state=present update_cache=yes cache_valid_time=3600
   with_items:
-    - ntp
     - git
     - tmux
     - iotop

--- a/roles/common/tasks/packages_Ubuntu.yml
+++ b/roles/common/tasks/packages_Ubuntu.yml
@@ -11,7 +11,6 @@
 - name: Install base packages
   apt: name={{ item }} state=present update_cache=yes
   with_items:
-    - ntp
     - git
     - tmux
     - iotop


### PR DESCRIPTION
systemd's `timedatectl` is a simple NTP client that is sufficient for most servers' network time needs and allows us to get rid of the `ntp` package dependency on those hosts.

Hosts can set their timezone in their host vars, ie:

```
timezone: Europe/London
```

To see a list of timezones use `timedatectl list-timezones`.

Closes #46.
