### PR TITLE
Add ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,3 +1,4 @@
 [defaults]
 pipelining=True
 retry_files_enabled=False
+inventory=hosts

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+pipelining=True
+retry_files_enabled=False

--- a/misc_plays/ansible.cfg
+++ b/misc_plays/ansible.cfg
@@ -1,0 +1,1 @@
+../ansible.cfg


### PR DESCRIPTION
Pipelining makes ansible run tasks much faster[0], and as of Ansible 2.0 or 2.1 or so, it now works on older hosts that have `requiretty` in their sudo config[1]. Also, disable the creation of those stupid retry files.

[0] https://docs.ansible.com/ansible/intro_configuration.html#pipelining
[1] https://github.com/ansible/ansible/pull/13200
