### PR TITLE
Use https:// transport for apt_key tasks

### DIFF
--- a/roles/common/tasks/packages_Ubuntu.yml
+++ b/roles/common/tasks/packages_Ubuntu.yml
@@ -3,7 +3,7 @@
   template: src=sources.list.j2 dest=/etc/apt/sources.list owner=root group=root mode=0644
 
 - name: Add GPG key for Extras repo
-  apt_key: id=0x3E5C1192 url=http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x16126D3A3E5C1192 state=present
+  apt_key: id=0x3E5C1192 url=https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x16126D3A3E5C1192 state=present
 
 - name: Upgrade base OS
   apt: upgrade=dist update_cache=yes cache_valid_time=3600

--- a/roles/common/tasks/raid-monitoring.yml
+++ b/roles/common/tasks/raid-monitoring.yml
@@ -6,7 +6,7 @@
   when: "ansible_os_family == 'Debian' and 'lsi' in hw_raid_vendor"
 
 - name: Import HWRaid repo's signing key
-  apt_key: url=http://hwraid.le-vert.net/debian/hwraid.le-vert.net.gpg.key state=present
+  apt_key: url=https://hwraid.le-vert.net/debian/hwraid.le-vert.net.gpg.key state=present
   when: "ansible_os_family == 'Debian' and 'lsi' in hw_raid_vendor"
 
 - name: Install LSI MegaCLI tools
@@ -26,7 +26,7 @@
   when: "ansible_os_family == 'Debian' and 'hp' in hw_raid_vendor and ansible_distribution_major_version >= '15'"
 
 - name: Import HP MCP repo's signing key
-  apt_key: url=http://downloads.linux.hpe.com/SDR/hpPublicKey2048_key1.pub state=present
+  apt_key: url=https://downloads.linux.hpe.com/SDR/hpPublicKey2048_key1.pub state=present
   when: "ansible_os_family == 'Debian' and 'hp' in hw_raid_vendor"
 
 - name: Install HP Array tools

--- a/roles/dspace/tasks/nginx.yml
+++ b/roles/dspace/tasks/nginx.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Add nginx.org apt signing key
-  apt_key: url=http://nginx.org/keys/nginx_signing.key state=present
+  apt_key: url=https://nginx.org/keys/nginx_signing.key state=present
 
 - name: Add nginx.org repo
   template: src=nginx_org_packages_ubuntu.list.j2 dest=/etc/apt/sources.list.d/nginx_org_packages_ubuntu.list mode=0644 owner=root group=root


### PR DESCRIPTION
I checked all the URLs and they all support https. Can't believe we didn't realize this ages ago.
