### PR TITLE
role/common: Only add signing key for Ubuntu Extras repo when distro is 14.04

### DIFF
--- a/roles/common/tasks/packages_Ubuntu.yml
+++ b/roles/common/tasks/packages_Ubuntu.yml
@@ -4,6 +4,7 @@
 
 - name: Add GPG key for Extras repo
   apt_key: id=0x3E5C1192 url=https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x16126D3A3E5C1192 state=present
+  when: ansible_distribution_version == '14.04'
 
 - name: Upgrade base OS
   apt: upgrade=dist update_cache=yes cache_valid_time=3600


### PR DESCRIPTION
The Ubuntu Extras repo was discontinued after Ubuntu 14.10 (and our sources.list template actually knows this already), so there is no point in adding the signing key on newer distros.
