### PR TITLE
Applying security updates using unattended-upgrades

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -12,6 +12,12 @@
   when: ansible_distribution == 'CentOS'
   tags: packages
 
+- include: unattended-upgrades.yml
+  when: ansible_os_family == 'Debian'
+  tags:
+    - unattended-upgrades
+    - packages
+
 - include: firewall.yml
   tags: firewall
 

--- a/roles/common/tasks/unattended-upgrades.yml
+++ b/roles/common/tasks/unattended-upgrades.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Install unattended-upgrades
+  apt: name=unattended-upgrades state=present update_cache=yes
+
+- name: Configure unattended-upgrades
+  template: src={{ item.src }} dest={{ item.dest }} mode=0644 owner=root group=root
+  with_items:
+    - { src: 'apt.conf.d/02periodic.j2', dest: '/etc/apt/apt.conf.d/02periodic' }
+    - { src: 'apt.conf.d/20auto-upgrades.j2', dest: '/etc/apt/apt.conf.d/20auto-upgrades' }
+    - { src: 'apt.conf.d/50unattended-upgrades.j2', dest: '/etc/apt/apt.conf.d/50unattended-upgrades' }
+
+# vim: set sw=2 ts=2:

--- a/roles/common/templates/apt.conf.d/02periodic.j2
+++ b/roles/common/templates/apt.conf.d/02periodic.j2
@@ -1,0 +1,20 @@
+// Enable the update/upgrade script (0=disable)
+APT::Periodic::Enable "1";
+
+// Do "apt-get update" automatically every n-days (0=disable)
+APT::Periodic::Update-Package-Lists "1";
+
+// Do "apt-get upgrade --download-only" every n-days (0=disable)
+APT::Periodic::Download-Upgradeable-Packages "7";
+
+// Do "apt-get autoclean" every n-days (0=disable)
+APT::Periodic::AutocleanInterval "14";
+
+// Send report mail to root
+//     0:  no report             (or null string)
+//     1:  progress report       (actually any string)
+//     2:  + command outputs     (remove -qq, remove 2>/dev/null, add -d)
+//     3:  + trace on
+APT::Periodic::Verbose "0";
+
+// vim: set filetype=aptconf sw=4 ts=4:

--- a/roles/common/templates/apt.conf.d/20auto-upgrades.j2
+++ b/roles/common/templates/apt.conf.d/20auto-upgrades.j2
@@ -1,0 +1,4 @@
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Unattended-Upgrade "1";
+
+// vim: set filetype=aptconf sw=4 ts=4:

--- a/roles/common/templates/apt.conf.d/50unattended-upgrades.j2
+++ b/roles/common/templates/apt.conf.d/50unattended-upgrades.j2
@@ -1,0 +1,61 @@
+// Automatically upgrade packages from these (origin:archive) pairs
+Unattended-Upgrade::Allowed-Origins {
+	"${distro_id}:${distro_codename}-security";
+//	"${distro_id}:${distro_codename}-updates";
+//	"${distro_id}:${distro_codename}-proposed";
+//	"${distro_id}:${distro_codename}-backports";
+};
+
+// List of packages to not update (regexp are supported)
+Unattended-Upgrade::Package-Blacklist {
+//	"vim";
+//	"libc6";
+//	"libc6-dev";
+//	"libc6-i686";
+};
+
+// This option allows you to control if on a unclean dpkg exit
+// unattended-upgrades will automatically run
+//   dpkg --force-confold --configure -a
+// The default is true, to ensure updates keep getting installed
+//Unattended-Upgrade::AutoFixInterruptedDpkg "false";
+
+// Split the upgrade into the smallest possible chunks so that
+// they can be interrupted with SIGUSR1. This makes the upgrade
+// a bit slower but it has the benefit that shutdown while a upgrade
+// is running is possible (with a small delay)
+//Unattended-Upgrade::MinimalSteps "true";
+
+// Install all unattended-upgrades when the machine is shuting down
+// instead of doing it in the background while the machine is running
+// This will (obviously) make shutdown slower
+//Unattended-Upgrade::InstallOnShutdown "true";
+
+// Send email to this address for problems or packages upgrades
+// If empty or unset then no email is sent, make sure that you
+// have a working mail setup on your system. A package that provides
+// 'mailx' must be installed. E.g. "user@example.com"
+Unattended-Upgrade::Mail "{{ sysadmin_emails|join(' ') }}";
+
+// Set this value to "true" to get emails only on errors. Default
+// is to always send a mail if Unattended-Upgrade::Mail is set
+Unattended-Upgrade::MailOnlyOnError "true";
+
+// Do automatic removal of new unused dependencies after the upgrade
+// (equivalent to apt-get autoremove)
+Unattended-Upgrade::Remove-Unused-Dependencies "true";
+
+// Automatically reboot *WITHOUT CONFIRMATION*
+//  if the file /var/run/reboot-required is found after the upgrade
+//Unattended-Upgrade::Automatic-Reboot "false";
+
+// If automatic reboot is enabled and needed, reboot at the specific
+// time instead of immediately
+//  Default: "now"
+//Unattended-Upgrade::Automatic-Reboot-Time "02:00";
+
+// Use apt bandwidth limit feature, this example limits the download
+// speed to 70kb/sec
+//Acquire::http::Dl-Limit "70";
+
+// vim: set filetype=aptconf ts=4 sw=4:


### PR DESCRIPTION
`unattended-upgrades` automatically downloads & installs security updates; just like `cron-apt` but even better.
1. https://wiki.debian.org/UnattendedUpgrades

Closes #54 
