### PR TITLE
ansible.cfg: Fix SSH pipelining config

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,4 +1,6 @@
 [defaults]
-pipelining=True
 retry_files_enabled=False
 inventory=hosts
+
+[ssh_connection]
+pipelining=True


### PR DESCRIPTION
The docs aren't very clear on this to be honest, but this option needs to be under an `[ssh_connection]` section.

See: http://docs.ansible.com/ansible/intro_configuration.html#pipelining
See: https://review.openstack.org/#/c/331499/
