### PR TITLE
group_vars/dspace: Fix Tomcat port for munin plugin

### DIFF
--- a/group_vars/dspace
+++ b/group_vars/dspace
@@ -30,7 +30,7 @@ nginx_branch: stable
 
 munin_tomcat_user: ilri-munin
 # plain http connector for munin to query Tomcat status
-munin_tomcat_port: 8080
+munin_tomcat_port: 8081
 
 # postgresql version to deploy
 pg_version: 9.3


### PR DESCRIPTION
Our DSpace servers define a plain HTTP connector on 8081, not 8080.
