### PR TITLE
roles/dspace: Basic Let's Encrypt plumbing

### DIFF
--- a/roles/dspace/defaults/main.yml
+++ b/roles/dspace/defaults/main.yml
@@ -50,4 +50,14 @@ tomcat_group: tomcat7
 tomcat_user_home: /usr/share/tomcat7
 tomcat_version_major: 7
 
+# install certbot + dependencies?
+# True unless you're in development and using "localhost" + snakeoil certs
+use_letsencrypt: True
+
+# Directory root for Let's Encrypt certs
+letsencrypt_root: /etc/letsencrypt/live
+
+# Location of Let's Encrypt's certbot script
+letsencrypt_certbot_path: /opt/certbot-auto
+
 # vim: set sw=2 ts=2:

--- a/roles/dspace/files/renew-letsencrypt.timer
+++ b/roles/dspace/files/renew-letsencrypt.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Renew Let's Encrypt certificates
+
+[Timer]
+# twice a day, at midnight and noon
+OnCalendar=*-*-* 00,12:00:00
+# Add a random delay of 0–3600 seconds
+RandomizedDelaySec=3600
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/roles/dspace/tasks/letsencrypt.yml
+++ b/roles/dspace/tasks/letsencrypt.yml
@@ -1,0 +1,48 @@
+---
+# For now this only installs the Certbot Let's Encrypt client, installs some
+# dependencies, and configures the systemd timer for certificate renewals.
+#
+# To use it, add `use_letsencrypt: True` to a host's variables and run the
+# "letsencrypt" tag.
+
+- name: Copy systemd service to renew Let's Encrypt certs
+  template: src=renew-letsencrypt.service.j2 dest=/etc/systemd/system/renew-letsencrypt.service mode=0644 owner=root group=root
+  register: letsencrypt_service
+
+- name: Copy systemd timer to renew Let's Encrypt certs
+  copy: src=renew-letsencrypt.timer dest=/etc/systemd/system/renew-letsencrypt.timer mode=0644 owner=root group=root
+  register: letsencrypt_timer
+
+# need to reload to pick up service/timer changes
+- name: Reload systemd daemon
+  command: /bin/systemctl daemon-reload
+  when: letsencrypt_service|changed or letsencrypt_timer|changed
+
+- name: Start and enable systemd timer to renew Let's Encrypt certs
+  service: name=renew-letsencrypt.timer state=started enabled=yes
+
+- name: Download certbot
+  get_url: dest={{ letsencrypt_certbot_path }} url=https://dl.eff.org/certbot-auto mode=700
+
+# dependencies certbot checks for on its first run
+- name: Install certbot dependencies (Ubuntu 16.04)
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_version == '16.04'
+  apt: name={{ item }} state=present update_cache=yes
+  with_items:
+    - libexpat1-dev
+    - libpython-dev
+    - libpython2.7
+    - libpython2.7-dev
+    - python-pip-whl
+    - python-pkg-resources
+    - python2.7-dev
+    - python3-virtualenv
+    - augeas-doc
+    - augeas-tools
+    - dialog
+    - python-dev
+    - python-virtualenv
+    - virtualenv
+  tags: packages
+
+# vim: set ts=2 sw=2:

--- a/roles/dspace/tasks/nginx.yml
+++ b/roles/dspace/tasks/nginx.yml
@@ -46,4 +46,11 @@
 - name: Start & enable nginx service
   service: name=nginx state=started enabled=yes
 
+# for now this playbook only installs certbot and systemd renewal scripts
+- include: letsencrypt.yml
+  when: use_letsencrypt is defined and
+        use_letsencrypt == True and
+        ansible_service_mgr == 'systemd'
+  tags: letsencrypt
+
 # vim: set sw=2 ts=2:

--- a/roles/dspace/templates/renew-letsencrypt.service.j2
+++ b/roles/dspace/templates/renew-letsencrypt.service.j2
@@ -1,0 +1,7 @@
+[Unit]
+Description=Renew Let's Encrypt certificates
+ConditionFileIsExecutable={{ letsencrypt_certbot_path }}
+
+[Service]
+Type=oneshot
+ExecStart={{ letsencrypt_certbot_path }} renew --standalone --pre-hook "/bin/systemctl stop nginx" --post-hook "/bin/systemctl start nginx"


### PR DESCRIPTION
Installs certbot client, its dependencies, and systemd timer + service for certificate renewal. Still requires you to manually run certbot to get the certificates, though. Defaults to installing for all Ubuntu 16.04 hosts running the `dspace` role, but can be disabled with `use_letsencrypt: False` in host vars if the host is using some other certs (like snakeoil for local development).

Future improvements:
- Use a [`cli.ini` configuration template](https://certbot.eff.org/docs/using.html#configuration-file)

Closes #39.
