### PR TITLE
roles/dspace: Add a Crawler Sessions Manager valve to server.xml

### DIFF
--- a/roles/dspace/templates/tomcat/server-tomcat7.xml.j2
+++ b/roles/dspace/templates/tomcat/server-tomcat7.xml.j2
@@ -154,6 +154,10 @@
                pattern="%h %l %u %t &quot;%r&quot; %s %b"
                rotatable="false" />
 
+        <!-- Crawler Session Manager Valve helps mitigate damage done by web crawlers -->
+        <Valve className="org.apache.catalina.valves.CrawlerSessionManagerValve"
+               crawlerUserAgents=".*[bB]ot.*|.*Yahoo! Slurp.*|.*Feedfetcher-Google.*|.*Baiduspider.*" />
+
       </Host>
     </Engine>
   </Service>

--- a/roles/dspace/templates/tomcat/server-tomcat8.xml.j2
+++ b/roles/dspace/templates/tomcat/server-tomcat8.xml.j2
@@ -154,6 +154,10 @@
                pattern="%h %l %u %t &quot;%r&quot; %s %b"
                rotatable="false" />
 
+        <!-- Crawler Session Manager Valve helps mitigate damage done by web crawlers -->
+        <Valve className="org.apache.catalina.valves.CrawlerSessionManagerValve"
+               crawlerUserAgents=".*[bB]ot.*|.*Yahoo! Slurp.*|.*Feedfetcher-Google.*|.*Baiduspider.*" />
+
       </Host>
     </Engine>
   </Service>


### PR DESCRIPTION
Tomcat has a nice feature to limit the overhead caused by creating sessions for relentless web spiders. The Crawler Sessions Manager internally maps all sessions associated with web spiders to one single session, which drastically reduces the resource penalty of getting hammered by these spiders.

The default regex doesn't match Baiduspider, which is our biggest offender, so I've added it.

See: https://tomcat.apache.org/tomcat-7.0-doc/config/valve.html