### PR TITLE
roles/dspace: Install Java meta package

### DIFF
--- a/roles/dspace/tasks/main.yml
+++ b/roles/dspace/tasks/main.yml
@@ -50,7 +50,7 @@
     - packages
 
 - name: Install Oracle Java
-  apt: pkg=oracle-java{{ java_version_major }}-installer state=present
+  apt: pkg=oracle-java{{ java_version_major }}-set-default state=present
   tags:
     - java
     - packages


### PR DESCRIPTION
Instead of installing the Java "installer" package from the WebUpd8 PPA, we should be using the meta package that installs the version we want, as well as setting it to be the system default.

The "set default" meta package depends on the "installer" package anyways, so this is mostly just a "just in case" change to protect against the case when a host might have two versions of Java, for instance when it drifts from the playbook config after a few months/years.

```console
# apt show oracle-java7-set-default
Package: oracle-java7-set-default
Version: 7u80+7u60arm-0~webupd8~1
Priority: optional
Section: java
Source: oracle-java7-installer
Maintainer: Alin Andrei <webupd8@gmail.com>
Installed-Size: 37.9 kB
Depends: oracle-java7-installer
Conflicts: oracle-java6-set-default, oracle-java8-set-default
Replaces: oracle-java6-set-default, oracle-java8-set-default
Download-Size: 4,782 B
APT-Sources: http://ppa.launchpad.net/webupd8team/java/ubuntu xenial/main amd64 Packages
Description: Set Oracle JDK 7 as default Java
 This package sets Java 7 as default (JAVA_HOME, PATH, etc.)
```