### PR TITLE
group_vars/dspace: Set default PostgreSQL version to 9.5

### DIFF
--- a/group_vars/dspace
+++ b/group_vars/dspace
@@ -33,6 +33,6 @@ munin_tomcat_user: ilri-munin
 munin_tomcat_port: 8081
 
 # postgresql version to deploy
-pg_version: 9.3
+pg_version: 9.5
 
 # vim: set ts=2 sw=2:


### PR DESCRIPTION
9.5 has been running in DEV (my laptop) and TEST (DSpace Test) environments for a few months now.

Closes #40