### PR TITLE
roles/dspace: Set default Java version to 8

### DIFF
--- a/roles/dspace/defaults/main.yml
+++ b/roles/dspace/defaults/main.yml
@@ -43,7 +43,7 @@ dspace_db_user: dspace
 dspace_db_password: Mz97%tU64J
 
 # default Oracle JDK version
-java_version_major: 7
+java_version_major: 8
 
 tomcat_user: tomcat7
 tomcat_group: tomcat7


### PR DESCRIPTION
Running on DEV (my laptop) and TEST (DSpace Test) for months. Solr developers recommend using Java 8 on Solr 4.10+ anyways, so we should have done this a long time ago.

Closes #49