### PR TITLE
Revert "roles/dspace: Deny access to rest's find-by-metadata-field"

### DIFF
--- a/roles/dspace/templates/nginx/default.conf.j2
+++ b/roles/dspace/templates/nginx/default.conf.j2
@@ -246,11 +246,6 @@ server {
         {% endif %}
     }
 
-     # deny access until we can patch for DS-3250
-     location /rest/items/find-by-metadata-field {
-         deny all;
-     }
-
     include extra-security.conf;
 }
 


### PR DESCRIPTION
This reverts commit 137fb7ef646507d55b68cbd9ddb45afb231751ff.

The security issue was patched in DSpace, and the patch was deployed as part of the DSpace 5.5 migration on the production server.