### PR TITLE
roles/dspace: Increase Tomcat connector's maxHttpHeaderSize

### DIFF
--- a/roles/dspace/templates/tomcat/server-tomcat7.xml.j2
+++ b/roles/dspace/templates/tomcat/server-tomcat7.xml.j2
@@ -73,7 +73,8 @@
     <Connector port="8081" protocol="HTTP/1.1"
                connectionTimeout="20000"
                address="127.0.0.1"
-               URIEncoding="UTF-8" />
+               URIEncoding="UTF-8"
+               maxHttpHeaderSize="16384" />
 
    <!-- tell tomcat it's being proxied via 443 / scheme https -->
     <Connector port="8443" protocol="HTTP/1.1"


### PR DESCRIPTION
In DSpace configurations where a user has many permissions, either inherited from a group or assigned directly to the user, the size of the Solr query for many XMLUI Discovery actions becomes too large and causes an error. Increasing the maxHttpHeaderSize allows these queries to work properly (default is 8192, ie 8KB).

This error is caused by the access rights awareness functionality that is enabled by default on DSpace 4, 5, and 6. There are many discussions about errors caused by this on the dspace-tech mailing list.

See: http://tomcat.apache.org/tomcat-7.0-doc/config/http.html
See: https://wiki.duraspace.org/display/DSDOC5x/Discovery#Discovery-AccessRightsAwareness