### PR TITLE
roles/dspace: Enable logging of /rest requests

### DIFF
--- a/roles/dspace/templates/nginx/default.conf.j2
+++ b/roles/dspace/templates/nginx/default.conf.j2
@@ -217,6 +217,12 @@ server {
         {% endif %}
     }
 
+    # log rest requests
+    location /rest {
+        access_log /var/log/nginx/rest.log;
+        proxy_pass http://127.0.0.1:8443;
+    }
+
     # Only allow Solr access from localhost
     location /solr {
         allow 127.0.0.1;


### PR DESCRIPTION
The backend Tomcat logs don't show IPs for request so there's no way to correlate large queries that might be causing Solr to crash.