### PR TITLE
roles/dspace: Use a variable for nginx TLS port

### DIFF
--- a/roles/dspace/defaults/main.yml
+++ b/roles/dspace/defaults/main.yml
@@ -13,6 +13,7 @@ nginx_ssl_session_cache: shared:SSL:10m
 nginx_ssl_buffer_size: 1400
 nginx_ssl_dhparam: /etc/ssl/certs/dhparam.pem
 nginx_ssl_protocols: 'TLSv1 TLSv1.1 TLSv1.2'
+nginx_ssl_port: 443
 nginx_spdy_headers_comp: 6
 
 # Use 301 (permanent) or 302 (temporary) redirects?

--- a/roles/dspace/templates/nginx/blank-vhost.conf.j2
+++ b/roles/dspace/templates/nginx/blank-vhost.conf.j2
@@ -11,8 +11,8 @@ server {
 }
 
 server {
-    listen 443 ssl http2 default_server;
-    listen [::]:443 ssl http2 default_server;
+    listen {{ nginx_ssl_port }} ssl http2 default_server;
+    listen [::]:{{ nginx_ssl_port }} ssl http2 default_server;
     # specify an invalid hostname that will never match
     # see: http://nginx.org/en/docs/http/server_names.html
     server_name _;

--- a/roles/dspace/templates/nginx/default.conf.j2
+++ b/roles/dspace/templates/nginx/default.conf.j2
@@ -143,8 +143,8 @@ server {
 #
 server {
     {% if nginx_tls_cert is defined %}
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen {{ nginx_ssl_port }} ssl http2;
+    listen [::]:{{ nginx_ssl_port }} ssl http2;
     {% else %}
     listen 80;
     listen [::]:80;

--- a/roles/dspace/templates/tomcat/server-tomcat7.xml.j2
+++ b/roles/dspace/templates/tomcat/server-tomcat7.xml.j2
@@ -76,12 +76,12 @@
                URIEncoding="UTF-8"
                maxHttpHeaderSize="16384" />
 
-   <!-- tell tomcat it's being proxied via 443 / scheme https -->
+   <!-- tell tomcat it's being proxied via {{ nginx_ssl_port }} / scheme https -->
     <Connector port="8443" protocol="HTTP/1.1"
                connectionTimeout="20000"
                address="127.0.0.1"
                URIEncoding="UTF-8"
-               proxyPort="443"
+               proxyPort="{{ nginx_ssl_port }}"
                scheme="https"
                secure="true" />
     <!-- A "Connector" using the shared thread pool-->

--- a/roles/dspace/templates/tomcat/server-tomcat8.xml.j2
+++ b/roles/dspace/templates/tomcat/server-tomcat8.xml.j2
@@ -75,12 +75,12 @@
                URIEncoding="UTF-8"
                maxHttpHeaderSize="16384" />
 
-   <!-- tell tomcat it's being proxied via 443 / scheme https -->
+   <!-- tell tomcat it's being proxied via {{ nginx_ssl_port }} / scheme https -->
     <Connector port="8443" protocol="HTTP/1.1"
                connectionTimeout="20000"
                address="127.0.0.1"
                URIEncoding="UTF-8"
-               proxyPort="443"
+               proxyPort="{{ nginx_ssl_port }}"
                scheme="https"
                secure="true" />
     <!-- A "Connector" using the shared thread pool-->


### PR DESCRIPTION
Allowing this to be overridden by host_vars makes it much easier to run this role in a development environment where the port might be forwarded via VirtualBox etc. Tomcat needs to know the port that it is being proxied via, so we must set it there too.