### PR TITLE
DSpace Tomcat contexts

### DIFF
--- a/roles/dspace/tasks/main.yml
+++ b/roles/dspace/tasks/main.yml
@@ -99,6 +99,15 @@
     - restart tomcat{{ tomcat_version_major }}
   tags: tomcat
 
+- name: Remove Tomcat mangement contexts
+  file: path=/var/lib/tomcat{{ tomcat_version_major }}/conf/Catalina/localhost/{{ item }} state=absent
+  with_items:
+    - host-manager.xml
+    - manager.xml
+  notify:
+    - restart tomcat{{ tomcat_version_major }}
+  tags: tomcat
+
 - name: Enable Tomcat
   service: name=tomcat{{ tomcat_version_major }} enabled=yes
   tags: tomcat


### PR DESCRIPTION
We don't need these contexts on production so we should remove them.

Depends on #68.