### PR TITLE
roles/dspace: Use dspace_root variable in handle cron job

### DIFF
--- a/roles/dspace/templates/dspace-handle-server.j2
+++ b/roles/dspace/templates/dspace-handle-server.j2
@@ -2,4 +2,4 @@
 # Start the DSpace handle server
 #
 
-@reboot {{ tomcat_user }} /home/{{ nginx_server_name }}/bin/start-handle-server
+@reboot {{ tomcat_user }} {{ dspace_root }}/bin/start-handle-server


### PR DESCRIPTION
It's bad to assume that `/home` + `nginx_server_name` will be where the DSpace root is. Instead, just use the host's `dspace_root` variable directly. In theory these are the same, but it's better to just use
the correct variable.