### PR TITLE
Use variable for PostgreSQL shared buffers

### DIFF
--- a/group_vars/dspace
+++ b/group_vars/dspace
@@ -35,4 +35,9 @@ munin_tomcat_port: 8081
 # postgresql version to deploy
 pg_version: 9.5
 
+# Use 10% of system RAM for PostgreSQL buffers (docs say 25% for dedicated SQL
+# boxes, but we also run Tomcat and rely on some OS cache for Solr, etc)
+# See: https://www.postgresql.org/docs/current/static/runtime-config-resource.html
+pg_shared_buffers: "{{ (ansible_memtotal_mb*0.1)|int|abs }}MB"
+
 # vim: set ts=2 sw=2:

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -6,5 +6,6 @@ pg_tls_cipher_suite: "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:
 pg_version: 9.3
 pg_conf_dir: "/etc/postgresql/{{ pg_version }}/main"
 pg_listen_addresses: "localhost"
+pg_shared_buffers: "128MB"
 
 # vim: set sw=2 ts=2:

--- a/roles/postgres/templates/postgresql-9.3.conf.j2
+++ b/roles/postgres/templates/postgresql-9.3.conf.j2
@@ -113,7 +113,7 @@ ssl_key_file = '/etc/ssl/private/ssl-cert-snakeoil.key'		# (change requires rest
 
 # - Memory -
 
-shared_buffers = 128MB			# min 128kB
+shared_buffers = {{ pg_shared_buffers }}			# min 128kB
 					# (change requires restart)
 #temp_buffers = 8MB			# min 800kB
 #max_prepared_transactions = 0		# zero disables the feature

--- a/roles/postgres/templates/postgresql-9.5.conf.j2
+++ b/roles/postgres/templates/postgresql-9.5.conf.j2
@@ -114,7 +114,7 @@ ssl_key_file = '/etc/ssl/private/ssl-cert-snakeoil.key'		# (change requires rest
 
 # - Memory -
 
-shared_buffers = 128MB			# min 128kB
+shared_buffers = {{ pg_shared_buffers }}			# min 128kB
 					# (change requires restart)
 #huge_pages = try			# on, off, or try
 					# (change requires restart)


### PR DESCRIPTION
First, allow the `shared_buffers` configuration option to be a variable (with a role default to the PostgreSQL default of 128MB). Second, set the `shared_buffers` value on DSpace hosts to be 10% of system RAM. The default behavior for existing hosts does not change.

This is based on the [PostgreSQL documentation](https://www.postgresql.org/docs/9.5/static/runtime-config-resource.html) which states that dedicated SQL servers should use 25% of their system's RAM for `shared_buffers`. Our DSpace servers are not dedicated SQL servers, but SQL is important, so let's use 10%.