### PR TITLE
Allow custom PostgreSQL settings

### DIFF
--- a/group_vars/dspace
+++ b/group_vars/dspace
@@ -35,4 +35,10 @@ munin_tomcat_port: 8081
 # postgresql version to deploy
 pg_version: 9.5
 
+# Use 10% of system RAM for PostgreSQL buffers (docs say 25% for dedicated SQL
+# boxes, but we also run Tomcat and rely on some OS cache for Solr, etc)
+# See: https://www.postgresql.org/docs/current/static/runtime-config-resource.html
+pg_confd_vars:
+  - { name: "shared_buffers", value: "{{ (ansible_memtotal_mb*0.1)|int|abs }}MB" }
+
 # vim: set ts=2 sw=2:

--- a/roles/postgres/tasks/ubuntu.yml
+++ b/roles/postgres/tasks/ubuntu.yml
@@ -22,6 +22,11 @@
 - name: Create additional postgresql configs. directory
   file: path={{ pg_conf_dir }}/conf.d mode=0755 owner=postgres group=postgres state=directory
 
+- name: Set custom postgresql variables
+  template: src=pg_confd_vars.conf.j2 dest={{ pg_conf_dir }}/conf.d/custom_vars.conf mode=0644 owner=postgres group=postgres
+  when: pg_confd_vars is defined
+  notify: restart postgres
+
 - name: Copy postgres configs
   template: src={{ item.src }} dest={{ item.dest }} mode={{ item.mode }} owner={{ item.owner }} group={{ item.group }}
   with_items:

--- a/roles/postgres/templates/pg_confd_vars.conf.j2
+++ b/roles/postgres/templates/pg_confd_vars.conf.j2
@@ -1,0 +1,3 @@
+{% for var in pg_confd_vars %}
+{{ var.name }} = {{ var.value }}
+{% endfor %}


### PR DESCRIPTION
Allows hosts and groups to override settings variables in their host and group vars by specifying a list of dicts with variable names and values. Also, sets the `shared_buffers` variable to 10% of system RAM for hosts in the DSpace group.

Use this instead of #71.