### PR TITLE
Fix Munin graphs in DSpace role

### DIFF
--- a/roles/dspace/tasks/main.yml
+++ b/roles/dspace/tasks/main.yml
@@ -99,15 +99,6 @@
     - restart tomcat{{ tomcat_version_major }}
   tags: tomcat
 
-- name: Remove Tomcat mangement contexts
-  file: path=/var/lib/tomcat{{ tomcat_version_major }}/conf/Catalina/localhost/{{ item }} state=absent
-  with_items:
-    - host-manager.xml
-    - manager.xml
-  notify:
-    - restart tomcat{{ tomcat_version_major }}
-  tags: tomcat
-
 - name: Enable Tomcat
   service: name=tomcat{{ tomcat_version_major }} enabled=yes
   tags: tomcat

--- a/roles/dspace/templates/nginx/default.conf.j2
+++ b/roles/dspace/templates/nginx/default.conf.j2
@@ -229,6 +229,12 @@ server {
         deny all;
     }
 
+    # Only allow access to management contexts from localhost (for Munin tomcat)
+    location ~ /(host-manager|manager) {
+        allow 127.0.0.1;
+        deny all;
+    }
+
     # Only allow jspui access for atmire modules
     location /jspui {
         location ~ ^/jspui/(export|listings-and-reports) {


### PR DESCRIPTION
I had removed the Tomcat management contexts because we never use them, but didn't realize that Munin's Tomcat plugin uses the `manager` context. It's better to limit access to these contexts to localhost using nginx than removing them.