### PR TITLE
roles/dspace: Add cron job for DSpace maintenance

### DIFF
--- a/roles/dspace/tasks/main.yml
+++ b/roles/dspace/tasks/main.yml
@@ -152,8 +152,11 @@
   become_user: postgres
   tags: postgres
 
-- name: Set up cron job for Handle server
-  template: src=dspace-handle-server.j2 dest=/etc/cron.d/dspace-handle-server owner=root group=root mode=644
+- name: Set up cron jobs
+  template: src={{ item }} dest=/etc/cron.d/{{ item | replace(".j2", "") }} owner=root group=root mode=644
+  with_items:
+    - dspace-handle-server.j2
+    - dspace-maintenance-tasks.j2
 
 - name: Create DSpace install directory
   file: path={{ dspace_root }} owner={{ tomcat_user }} group={{ tomcat_group }} mode=0755 state=directory

--- a/roles/dspace/templates/dspace-maintenance-tasks.j2
+++ b/roles/dspace/templates/dspace-maintenance-tasks.j2
@@ -1,0 +1,104 @@
+#-----------------
+# GLOBAL VARIABLES
+#-----------------
+# Full path of your local DSpace Installation (e.g. /home/dspace or /dspace or similar)
+# MAKE SURE TO CHANGE THIS VALUE!!!
+DSPACE={{ dspace_root }}
+
+# Shell to use
+SHELL=/bin/sh
+
+# Add all major 'bin' directories to path
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
+# Set JAVA_OPTS with defaults for DSpace Cron Jobs.
+# Only provides 512MB of memory by default (which should be enough for most sites).
+JAVA_OPTS="-Xmx1024M -Dfile.encoding=UTF-8"
+
+#--------------
+# HOURLY TASKS (Recommended to be run multiple times per day, if possible)
+# At a minimum these tasks should be run daily.
+#--------------
+
+# Regenerate DSpace Sitemaps every 8 hours (12AM, 8AM, 4PM).
+# SiteMaps ensure that your content is more findable in Google, Google Scholar, and other major search engines.
+0 0,8,16 * * * {{ tomcat_user }} $DSPACE/bin/dspace generate-sitemaps >> $DSPACE/log/cron-sitemaps.log.$(date --iso-8601) 2>&1
+
+#----------------
+# DAILY TASKS
+# (Recommended to be run once per day. Feel free to tweak the scheduled times below.)
+#----------------
+
+# Update the OAI-PMH index with the newest content (and re-optimize that index) at midnight every day
+# NOTE: ONLY NECESSARY IF YOU ARE RUNNING OAI-PMH
+# (This ensures new content is available via OAI-PMH and ensures the OAI-PMH index is optimized for better performance)
+0 0 * * * {{ tomcat_user }} $DSPACE/bin/dspace oai import -o > /dev/null
+0 1 * * * {{ tomcat_user }} $DSPACE/bin/dspace oai clean-cache > /dev/null
+# Clean and Update the Discovery indexes at midnight every day
+# (This ensures that any deleted documents are cleaned from the Discovery search/browse index)
+0 0 * * * {{ tomcat_user }} schedtool -B -e ionice -c2 -n7 $DSPACE/bin/dspace index-discovery > /dev/null
+0 6 * * * {{ tomcat_user }} schedtool -B -e ionice -c2 -n7 $DSPACE/bin/dspace dsrun com.atmire.statistics.util.UpdateSolrStorageReports > /dev/null
+0 6 * * * {{ tomcat_user }} schedtool -B -e ionice -c2 -n7 $DSPACE/bin/dspace dsrun com.atmire.utils.ReportSender > /dev/null
+# Re-Optimize the Discovery indexes at 12:30 every day
+# (This ensures that the Discovery Solr Index is re-optimized for better performance)
+# Disabled 2016-09, see: https://issues.apache.org/jira/browse/SOLR-3141
+# 30 0 * * * {{ tomcat_user }} schedtool -B -e ionice -c2 -n7 $DSPACE/bin/dspace index-discovery -o > /dev/null
+
+# run the index-authority script once a day at 12:45 to ensure the Solr Authority cache is up to date
+45 0 * * * {{ tomcat_user }} schedtool -B -e ionice -c2 -n7 $DSPACE/bin/dspace index-authority > /dev/null
+
+# Re-Optimize DSpace Statistics Solr Index at 01:30 every day
+# NOTE: ONLY NECESSARY IF YOU ARE RUNNING SOLR STATISTICS
+# (This ensures that the Statistics Solr Index is re-optimized for better performance)
+# Disabled 2016-09, see: https://issues.apache.org/jira/browse/SOLR-3141
+#30 1 * * * {{ tomcat_user }} schedtool -B -e ionice -c2 -n7 $DSPACE/bin/dspace stats-util -o
+
+# Send out subscription e-mails at 02:00 every day
+# (This sends an email to any users who have "subscribed" to a Collection, notifying them of newly added content.)
+0 2 * * * {{ tomcat_user }} $DSPACE/bin/dspace sub-daily
+
+# Run the media filter at 03:00 every day.
+# (This task ensures that thumbnails are generated for newly add images,
+# and also ensures full text search is available for newly added PDF/Word/PPT/HTML documents)
+0 3 * * * {{ tomcat_user }} schedtool -B -e ionice -c2 -n7 $DSPACE/bin/dspace filter-media >> $DSPACE/log/cron-filter-media.log.$(date --iso-8601) 2>&1
+
+# Run any Curation Tasks queued from the Admin UI at 04:00 every day
+# (Ensures that any curation task that an administrator "queued" from the Admin UI is executed
+# asynchronously behind the scenes)
+0 4 * * * {{ tomcat_user }} $DSPACE/bin/dspace curate -q admin_ui
+
+#----------------
+# WEEKLY TASKS
+# (Recommended to be run once per week, but can be run more or less frequently, based on your local needs/policies)
+#----------------
+# Run the checksum checker at 04:00 every Sunday
+# By default it runs through every file (-l) and also prunes old results (-p)
+# (This re-verifies the checksums of all files stored in DSpace. If any files have been changed/corrupted, checksums will differ.)
+# 0 4 * * * $DSPACE/bin/dspace checker -l -p
+# NOTE: LARGER SITES MAY WISH TO USE DIFFERENT OPTIONS. The above "-l" option tells DSpace to check *everything*.
+# If your site is very large, you may need to only check a portion of your content per week. The below commented-out task
+# would instead check all the content it can within *one hour*. The next week it would start again where it left off.
+# Check twice a week, for 1 hour each time.
+0 4 * * 0,3 {{ tomcat_user }} schedtool -B -e ionice -c2 -n7 $DSPACE/bin/dspace checker -d 1h -p >> $DSPACE/log/cron-checker.log.$(date --iso-8601) 2>&1
+
+# Mail the results of the checksum checker (see above) to the configured "mail.admin" at 05:00 every Sunday.
+# (This ensures the system administrator is notified whether any checksums were found to be different.)
+0 5 * * 0 {{ tomcat_user }} $DSPACE/bin/dspace checker-emailer
+
+#----------------
+# MONTHLY TASKS
+# (Recommended to be run once per month, but can be run more or less frequently, based on your local needs/policies)
+#----------------
+# Permanently delete any bitstreams flagged as "deleted" in DSpace, on the first of every month at 01:00
+# (This ensures that any files which were deleted from DSpace are actually removed from your local filesystem.
+# By default they are just marked as deleted, but are not removed from the filesystem.)
+0 1 1 * * {{ tomcat_user }} schedtool -B -e ionice -c2 -n7 $DSPACE/bin/dspace cleanup > /dev/null
+
+#----------------
+# YEARLY TASKS (Recommended to be run once per year)
+#----------------
+# At 2:00AM every January 1, "shard" the DSpace Statistics Solr index.
+# This ensures each year has its own Solr index, which improves performance.
+# NOTE: ONLY NECESSARY IF YOU ARE RUNNING SOLR STATISTICS
+# NOTE: This is scheduled here for 2:00AM so that it happens *after* the daily cleaning & re-optimization of this index.
+0 2 1 1 * {{ tomcat_user }} schedtool -B -e ionice -c2 -n7 $DSPACE/bin/dspace stats-util -s >> $DSPACE/log/cron-stats-util.log.$(date --iso-8601) 2>&1


### PR DESCRIPTION
These were originally based on the [scheduled tasks from the DSpace documentation](https://wiki.duraspace.org/display/DSDOC5x/Scheduled+Tasks+via+Cron) but I have modified them slightly. They should be checked every new DSpace release to make sure they are current.

They had previously been manually maintained in the tomcat user's profile via `crontab -e` but this is kinda hacky and I've been meaning to get them under Ansible control for a while. I have left some things in—like using the `$DSPACE` variable—so that it's easier to compare them to the cron jobs from the official documentation.

After running this, the cron jobs in the `tomcat7` user's account must be manually commented out or deleted via `crontab -e`.