### PR TITLE
roles/dspace: Enable nginx OCSP stapling on Ubuntu > 16.04

### DIFF
--- a/roles/dspace/defaults/main.yml
+++ b/roles/dspace/defaults/main.yml
@@ -16,6 +16,10 @@ nginx_ssl_protocols: 'TLSv1 TLSv1.1 TLSv1.2'
 nginx_ssl_port: 443
 nginx_spdy_headers_comp: 6
 
+# DNS resolvers for OCSP stapling (default to Google public DNS)
+# See: https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_stapling
+nginx_ssl_stapling_resolver: '8.8.8.8 8.8.4.4 [2001:4860:4860::8888] [2001:4860:4860::8844]'
+
 # Use 301 (permanent) or 302 (temporary) redirects?
 # 301 on production, 302 on development!
 nginx_redirect_type: 301

--- a/roles/dspace/templates/nginx/default.conf.j2
+++ b/roles/dspace/templates/nginx/default.conf.j2
@@ -172,6 +172,12 @@ server {
     ssl_ciphers "{{ tls_cipher_suite }}";
     ssl_prefer_server_ciphers on;
 
+    {% if ansible_distribution == 'Ubuntu' and ansible_distribution_version | version_compare('16.04', '>=') %}
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    resolver {{ nginx_ssl_stapling_resolver }};
+    {% endif %}
+
     # nginx does not auto-rotate session ticket keys: only a HUP / restart will do so and
     # when a restart is performed the previous key is lost, which resets all previous
     # sessions. The fix for this is to setup a manual rotation mechanism:


### PR DESCRIPTION
With OCSP stapling the HTTP server can give a cached OCSP response to the client, which saves the client from doing the lookup itself. This helps reduce the overhead from the TLS handshake.

Uses the Google public DNS servers (IPv4 and IPv6) by default, but can be overridden for groups and hosts to use specific ones from the hosting provider—Linode provides DNS servers that are one hop away from its VPSes, for example.

We've been waiting until our hosts were running openssl >= 1.0.2 to enable this (Ubuntu 16.04 in this case).

See: https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_stapling
See: https://developers.google.com/speed/public-dns/docs/using
See: https://github.com/ilri/DSpace/issues/38