### PR TITLE
Use Ansible's version_compare() filter

### DIFF
--- a/roles/common/tasks/firewall_CentOS.yml
+++ b/roles/common/tasks/firewall_CentOS.yml
@@ -4,30 +4,30 @@
 # Never run firewall rules on HPC
 
 - name: Copy /etc/sysconfig/iptables
-  when: inventory_hostname != 'hpc' and ansible_distribution_major_version == '6'
+  when: inventory_hostname != 'hpc' and ansible_distribution_major_version | version_compare('6', '==')
   template: src=iptables.j2 dest=/etc/sysconfig/iptables owner=root mode=0600
   notify:
     - restart iptables
 
 - name: Copy /etc/sysconfig/ip6tables
-  when: inventory_hostname != 'hpc' and ansible_distribution_major_version == '6'
+  when: inventory_hostname != 'hpc' and ansible_distribution_major_version | version_compare('6', '==')
   template: src=ip6tables.j2 dest=/etc/sysconfig/ip6tables owner=root group=root mode=0600
   notify:
     - restart ip6tables
 
 - name: Install tidy
-  when: ansible_distribution_major_version == '7'
+  when: ansible_distribution_major_version | version_compare('7', '==')
   yum: name={{ item }} state=present
   with_items:
     - tidy
   tags: packages
 
 - name: Copy firewalld public zone file to /etc/firewalld/zones/public.xml
-  when: inventory_hostname != 'hpc' and ansible_distribution_major_version == '7'
+  when: inventory_hostname != 'hpc' and ansible_distribution_major_version | version_compare('7', '==')
   template: src=public.xml.j2 dest=/etc/firewalld/zones/public.xml owner=root mode=0600
 
 - name: Format public.xml firewalld zone file
-  when: inventory_hostname != 'hpc' and ansible_distribution_major_version == '7'
+  when: inventory_hostname != 'hpc' and ansible_distribution_major_version | version_compare('7', '==')
   shell: tidy -xml -iq -m -w 0 /etc/firewalld/zones/public.xml
   notify:
     - restart firewalld

--- a/roles/common/tasks/firewall_Debian.yml
+++ b/roles/common/tasks/firewall_Debian.yml
@@ -3,24 +3,24 @@
 # Use firewalld on Debian 8
 
 - name: Install iptables-persistent
-  when: ansible_distribution_major_version == '7'
+  when: ansible_distribution_major_version | version_compare('7', '==')
   apt: name=iptables-persistent state=present update_cache=yes cache_valid_time=3600
   tags: packages
 
 - name: Copy /etc/iptables/rules.v4
-  when: ansible_distribution_major_version == '7'
+  when: ansible_distribution_major_version | version_compare('7', '==')
   template: src=iptables.j2 dest=/etc/iptables/rules.v4 owner=root group=root mode=0600
   notify:
     - restart iptables-persistent
 
 - name: Copy /etc/iptables/rules.v6
-  when: ansible_distribution_major_version == '7'
+  when: ansible_distribution_major_version | version_compare('7', '==')
   template: src=ip6tables.j2 dest=/etc/iptables/rules.v6 owner=root group=root mode=0600
   notify:
     - restart iptables-persistent
 
 - name: Install firewalld
-  when: ansible_distribution_major_version == '8'
+  when: ansible_distribution_major_version | version_compare('8', '==')
   apt: name={{ item }} state=present
   with_items:
     - firewalld
@@ -28,11 +28,11 @@
   tags: packages
 
 - name: Copy firewalld public zone file to /etc/firewalld/zones/public.xml
-  when: ansible_distribution_major_version == '8'
+  when: ansible_distribution_major_version | version_compare('8', '==')
   template: src=public.xml.j2 dest=/etc/firewalld/zones/public.xml owner=root mode=0600
 
 - name: Format public.xml firewalld zone file
-  when: ansible_distribution_major_version == '8'
+  when: ansible_distribution_major_version | version_compare('8', '==')
   shell: tidy -xml -iq -m -w 0 /etc/firewalld/zones/public.xml
   notify:
     - restart firewalld

--- a/roles/common/tasks/firewall_Ubuntu.yml
+++ b/roles/common/tasks/firewall_Ubuntu.yml
@@ -2,24 +2,24 @@
 # Use iptables-persistent on Ubuntu 14 & firewalld on Ubunt 15 onwards
 
 - name: Install iptables-persistent
-  when: ansible_distribution_major_version < '15'
+  when: ansible_distribution_major_version | version_compare('15', '<')
   apt: name=iptables-persistent state=present update_cache=yes cache_valid_time=3600
   tags: packages
 
 - name: Copy /etc/iptables/rules.v4
-  when: ansible_distribution_major_version < '15'
+  when: ansible_distribution_major_version | version_compare('15', '<')
   template: src=iptables.j2 dest=/etc/iptables/rules.v4 owner=root group=root mode=0600
   notify:
     - restart iptables-persistent
 
 - name: Copy /etc/iptables/rules.v6
-  when: ansible_distribution_major_version < '15'
+  when: ansible_distribution_major_version | version_compare('15', '<')
   template: src=ip6tables.j2 dest=/etc/iptables/rules.v6 owner=root group=root mode=0600
   notify:
     - restart iptables-persistent
 
 - name: Install firewalld
-  when: ansible_distribution_major_version >= '15'
+  when: ansible_distribution_major_version | version_compare('15', '>=')
   apt: name={{ item }} state=present
   with_items:
     - firewalld
@@ -27,11 +27,11 @@
   tags: packages
 
 - name: Copy firewalld public zone file to /etc/firewalld/zones/public.xml
-  when: ansible_distribution_major_version >= '15'
+  when: ansible_distribution_major_version | version_compare('15', '>=')
   template: src=public.xml.j2 dest=/etc/firewalld/zones/public.xml owner=root mode=0600
 
 - name: Format public.xml firewalld zone file
-  when: ansible_distribution_major_version >= '15'
+  when: ansible_distribution_major_version | version_compare('15', '>=')
   shell: tidy -xml -iq -m -w 0 /etc/firewalld/zones/public.xml
   notify:
     - restart firewalld

--- a/roles/common/tasks/packages_Ubuntu.yml
+++ b/roles/common/tasks/packages_Ubuntu.yml
@@ -4,7 +4,7 @@
 
 - name: Add GPG key for Extras repo
   apt_key: id=0x3E5C1192 url=https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x16126D3A3E5C1192 state=present
-  when: ansible_distribution_version == '14.04'
+  when: ansible_distribution_version | version_compare('14.04', '==')
 
 - name: Upgrade base OS
   apt: upgrade=dist update_cache=yes cache_valid_time=3600

--- a/roles/common/tasks/raid-monitoring.yml
+++ b/roles/common/tasks/raid-monitoring.yml
@@ -17,13 +17,13 @@
 # http://downloads.linux.hp.com/SDR/project/mcp/
 - name: Add Debian-based HP MCP repo
   apt_repository: repo='deb http://downloads.linux.hpe.com/SDR/repo/mcp {{ ansible_distribution_release }}/current non-free' state=present
-  when: "ansible_os_family == 'Debian' and 'hp' in hw_raid_vendor and ansible_distribution_major_version < '15'"
+  when: ansible_os_family == 'Debian' and 'hp' in hw_raid_vendor and ansible_distribution_major_version | version_compare('15', '<')
 
 # no xenial builds at the moment, so we'll use trusty's
 # http://downloads.linux.hpe.com/SDR/repo/mcp/dists/
 - name: Add Debian-based HP MCP repo on xenial and wily hosts
   apt_repository: repo='deb http://downloads.linux.hpe.com/SDR/repo/mcp trusty/current non-free' state=present
-  when: "ansible_os_family == 'Debian' and 'hp' in hw_raid_vendor and ansible_distribution_major_version >= '15'"
+  when: ansible_os_family == 'Debian' and 'hp' in hw_raid_vendor and ansible_distribution_major_version | version_compare('15', '>=')
 
 - name: Import HP MCP repo's signing key
   apt_key: url=https://downloads.linux.hpe.com/SDR/hpPublicKey2048_key1.pub state=present

--- a/roles/common/templates/sources.list.j2
+++ b/roles/common/templates/sources.list.j2
@@ -14,7 +14,7 @@ deb http://{{ apt_mirror }}/ubuntu/ {{ ansible_distribution_release }}-updates m
 ###### Ubuntu Partner Repo
 deb http://archive.canonical.com/ubuntu {{ ansible_distribution_release }} partner
 
-{% if ansible_distribution_version == '14.04' %}
+{% if ansible_distribution_version | version_compare('14.04', '==') %}
 {# extras repo was discontinued after 14.10 #}
 ###### Ubuntu Extras Repo
 deb http://extras.ubuntu.com/ubuntu {{ ansible_distribution_release }} main

--- a/roles/dspace/templates/tomcat/defaults-tomcat7.j2
+++ b/roles/dspace/templates/tomcat/defaults-tomcat7.j2
@@ -10,9 +10,9 @@ TOMCAT7_GROUP=tomcat7
 # JDK version 1.5. If JAVA_HOME is not set, some common directories for 
 # OpenJDK, the Sun JDK, and various J2SE 1.5 versions are tried.
 #JAVA_HOME=/usr/lib/jvm/openjdk-6-jdk
-{% if java_version_major == 7 %}
+{% if java_version_major | version_compare('7', '==') %}
 JAVA_HOME=/usr/lib/jvm/java-7-oracle
-{% elif java_version_major == 8 %}
+{% elif java_version_major | version_compare('8', '==') %}
 JAVA_HOME=/usr/lib/jvm/java-8-oracle
 {% endif %}
 

--- a/roles/dspace/templates/tomcat/defaults-tomcat8.j2
+++ b/roles/dspace/templates/tomcat/defaults-tomcat8.j2
@@ -10,9 +10,9 @@ TOMCAT8_GROUP=tomcat8
 # JDK version 7. If JAVA_HOME is not set, some common directories for
 # OpenJDK and the Oracle JDK are tried.
 #JAVA_HOME=/usr/lib/jvm/java-7-openjdk
-{% if java_version_major == 7 %}
+{% if java_version_major | version_compare('7', '==') %}
 JAVA_HOME=/usr/lib/jvm/java-7-oracle
-{% elif java_version_major == 8 %}
+{% elif java_version_major | version_compare( '8', '==') %}
 JAVA_HOME=/usr/lib/jvm/java-8-oracle
 {% endif %}
 

--- a/roles/sssd/tasks/sssd.yml
+++ b/roles/sssd/tasks/sssd.yml
@@ -43,7 +43,7 @@
   when: ansible_distribution == 'Ubuntu'
 
 - name: Change minimum PAM UID for SSH logins
-  when: ansible_distribution == 'CentOS' and ansible_distribution_major_version == '7'
+  when: ansible_distribution == 'CentOS' and ansible_distribution_major_version | version_compare('7', '==')
   replace: dest={{ item }} regexp='1000' replace='500'
   with_items:
    - /etc/pam.d/system-auth-ac


### PR DESCRIPTION
Instead of using strings to compare integer version numbers, we should use Ansible's [version_compare()](https://docs.ansible.com/ansible/playbooks_tests.html#version-comparison)

Closes #77 
