### PR TITLE
WIP: roles/dspace: Use proxy_pass to upstream in nginx

### DIFF
--- a/roles/dspace/files/nginx/proxy_params
+++ b/roles/dspace/files/nginx/proxy_params
@@ -9,3 +9,8 @@ proxy_set_header Proxy "";
 proxy_connect_timeout 3600;
 proxy_send_timeout 3600;
 proxy_read_timeout 3600;
+# Use HTTP/1.1 to upstream so we can use keepalive and reduce connection overhead
+# See: https://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive
+# See: https://ma.ttias.be/enable-keepalive-connections-in-nginx-upstream-proxy-configurations/
+proxy_http_version 1.1;
+proxy_set_header Connection "";

--- a/roles/dspace/templates/nginx/default.conf.j2
+++ b/roles/dspace/templates/nginx/default.conf.j2
@@ -79,7 +79,7 @@ server {
     # feedburner doesn't support https :(
     location ~ /(feed|open-search/discover) {
         # Send requests to Tomcat
-        proxy_pass http://127.0.0.1:8443;
+        proxy_pass http://tomcat_http;
     }
 
     # redirect http -> https
@@ -206,27 +206,18 @@ server {
     # see: https://jira.duraspace.org/browse/DS-2962
     location ~ /handle/10568/[0-9]+/(browse|discover|search-filter) {
         add_header X-Robots-Tag "none";
-
-        {% if nginx_tls_cert is defined %}
-        proxy_pass http://127.0.0.1:8443;
-        {% else %}
-        proxy_pass http://127.0.0.1:8081;
-        {% endif %}
+        proxy_pass http://tomcat_http;
     }
 
     location / {
         # Send requests to Tomcat
-        {% if nginx_tls_cert is defined %}
-        proxy_pass http://127.0.0.1:8443;
-        {% else %}
-        proxy_pass http://127.0.0.1:8081;
-        {% endif %}
+        proxy_pass http://tomcat_http;
     }
 
     # log rest requests
     location /rest {
         access_log /var/log/nginx/rest.log;
-        proxy_pass http://127.0.0.1:8443;
+        proxy_pass http://tomcat_http;
     }
 
     # Only allow Solr access from localhost
@@ -245,11 +236,7 @@ server {
     location /jspui {
         location ~ ^/jspui/(export|listings-and-reports) {
             allow all;
-            {% if nginx_tls_cert is defined %}
-            proxy_pass http://127.0.0.1:8443;
-            {% else %}
-            proxy_pass http://127.0.0.1:8081;
-            {% endif %}
+            proxy_pass http://tomcat_http;
         }
 
         deny all;
@@ -257,14 +244,23 @@ server {
 
     # named location for above try_files
     location @tomcat {
-        {% if nginx_tls_cert is defined %}
-        proxy_pass http://127.0.0.1:8443;
-        {% else %}
-        proxy_pass http://127.0.0.1:8081;
-        {% endif %}
+        proxy_pass http://tomcat_http;
     }
 
     include extra-security.conf;
+}
+
+upstream tomcat_http {
+    {% if nginx_tls_cert is defined %}
+    server 127.0.0.1:8443;
+    {% else %}
+    server 127.0.0.1:8081;
+    {% endif %}
+
+    # The keepalive parameter sets the maximum number of idle keepalive connections
+    # to upstream servers that are preserved in the cache of each worker process. When
+    # this number is exceeded, the least recently used connections are closed.
+    keepalive 60;
 }
 
 # vim: set ts=4 sw=4:


### PR DESCRIPTION
Using proxy_pass to an upstream server (instead of directly to the server's IP) allows us to let nginx use TCP keepalive when talking to the backend server as well as simplify the config a bit.

As it is now, nginx creates a new TCP connection to the backend for each client that connects to the front end—this enables it to keep some of the connections open so it can re-use them.

See: https://www.nginx.com/blog/http-keepalives-and-web-performance/
See: https://www.nginx.com/blog/tuning-nginx/
See: https://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive

**WIP: Don't merge. Running on DSpace Test. Still testing!**